### PR TITLE
Set axios's baseUrl to null

### DIFF
--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,4 +1,5 @@
 export default function ({ $axios, redirect, store }, inject) {
+  $axios.defaults.baseURL = null
   $axios.defaults.headers.common.Accept = 'application/json'
   $axios.defaults.withCredentials = true
 


### PR DESCRIPTION
The base URL for axios was remaining localhost even in prod