### PR TITLE
Added an option to run only the API server without nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 2. npm install
 3. npm run dev --spa
 
+## API only develoment
+If by any chance you might need to only run the api server alone you can do that by running the following
+`yarn dev:api` or `npm run dev:api`.
+ *Please not that the api server does not have the `/api` prefix eg getting users is as simple as `/users` because `/api/users` will result in a 404 response*
+
 ## Production
 1. npm run lint
 2. npm run test

--- a/api/app.js
+++ b/api/app.js
@@ -64,4 +64,11 @@ app.use('/groups', groupsRouter)
 app.use('/auth', authRouter)
 app.use('/events', eventsRouter)
 
-module.exports = app
+if (process.env.NODE_ENV === 'api') {
+  const port = process.env.PORT | 3000
+  app.listen(port, () => {
+    console.log(`API DEV server running on http://localhost:${port}`)
+  })
+} else {
+  module.exports = app
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "nuxt start --spa",
     "dev": "DEBUG=express:* nuxt",
+    "dev:api" : "DEBUG=express:* NODE_ENV=api node api/app.js",
     "pretest": "NODE_ENV=development knex migrate:latest",
     "test": "NODE_ENV=testing mocha --timeout 12000 --exit",
     "posttest": "rm dev.sqlite",


### PR DESCRIPTION
@wilcox98 this commit has the feature you asked for running only the API without `nuxt`