### PR TITLE
Dropped support for node 15.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x, 16.x, 17.x, 18.x]
+        node-version: [16.x, 17.x, 18.x]
         redis-version: [6]
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The goal is to support from LTS which is 16.x to the latest version of node